### PR TITLE
feat: add unlock cron task monitor

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@sentry/types": "^7.108.0",
     "@types/lodash": "^4.17.0",
     "@types/multicoin-address-validator": "^0.5.2",
     "@types/node": "^20.11.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ dependencies:
     version: 3.22.4
 
 devDependencies:
+  '@sentry/types':
+    specifier: ^7.108.0
+    version: 7.108.0
   '@types/lodash':
     specifier: ^4.17.0
     version: 4.17.0
@@ -1567,6 +1570,11 @@ packages:
     resolution: {integrity: sha512-htKorf3t/D0XYtM7foTcmG+rM47rDP6XdbvCcX5gBCuCYlzpM1vqCt2rl3FLktZC6TaIpFRJw1TLfx6m+x5jdA==}
     engines: {node: '>=8'}
     dev: false
+
+  /@sentry/types@7.108.0:
+    resolution: {integrity: sha512-bKtHITmBN3kqtqE5eVvL8mY8znM05vEodENwRpcm6TSrrBjC2RnwNWVwGstYDdHpNfFuKwC8mLY9bgMJcENo8g==}
+    engines: {node: '>=8'}
+    dev: true
 
   /@sentry/utils@7.102.1:
     resolution: {integrity: sha512-+8WcFjHVV/HROXSAwMuUzveElBFC43EiTG7SNEBNgOUeQzQVTmbUZXyTVgLrUmtoWqvnIxCacoLxtZo1o67kdg==}

--- a/src/env.ts
+++ b/src/env.ts
@@ -56,6 +56,7 @@ const envSchema = z.object({
 
   UNLOCKER_CRON_SCHEDULE: z.string().default('*/5 * * * *'),
   UNLOCKER_CELL_BATCH_SIZE: z.coerce.number().default(100),
+  UNLOCKER_MONITOR_SLUG: z.string().default('btctimelock-cells-unlock'),
 
   TRANSACTION_QUEUE_JOB_DELAY: z.coerce.number().default(120 * 1000),
 });


### PR DESCRIPTION
Monitor the status of the BTCTimeLock Cells Unlock cron task through the Sentry cron monitor. This facilitates monitoring and error handling of the task.

![CleanShot 2024-03-28 at 16 55 14@2x](https://github.com/ckb-cell/btc-assets-api/assets/9718515/3887c2da-67df-49a3-b12b-19141e90f764)


See: https://docs.sentry.io/platforms/node/crons/#check-ins