### PR TITLE
feat: simplify token route control

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -34,8 +34,6 @@ if (env.SENTRY_DSN_URL) {
   });
 }
 
-const isTokenRoutesEnable = env.NODE_ENV === 'production' ? env.ADMIN_USERNAME && env.ADMIN_PASSWORD : true;
-
 async function routes(fastify: FastifyInstance) {
   fastify.log.info(`Process env: ${JSON.stringify(getSafeEnvs(), null, 2)}`);
   if (Sentry.isInitialized()) {
@@ -55,9 +53,7 @@ async function routes(fastify: FastifyInstance) {
   await container.resolve('bitcoind').checkNetwork(env.NETWORK as NetworkType);
   await container.resolve('electrs').checkNetwork(env.NETWORK as NetworkType);
 
-  if (isTokenRoutesEnable) {
-    fastify.register(tokenRoutes, { prefix: '/token' });
-  }
+  fastify.register(tokenRoutes, { prefix: '/token' });
   fastify.register(bitcoinRoutes, { prefix: '/bitcoin/v1' });
   fastify.register(rgbppRoutes, { prefix: '/rgbpp/v1' });
   if (provider === 'vercel') {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { isGenerateTokenPrivate } from './env';
+
 export enum NetworkType {
   mainnet = 'prod',
   testnet = 'testnet',
@@ -14,6 +16,6 @@ export enum ApiCacheStatus {
 }
 
 export const JWT_IGNORE_URLS = ['/token', '/docs', '/cron'];
-export const SWAGGER_PROD_IGNORE_URLS = ['/token', '/cron'];
+export const SWAGGER_PROD_IGNORE_URLS = isGenerateTokenPrivate ? ['/token', '/cron'] : ['/cron'];
 
 export const VERCEL_MAX_DURATION = 300;

--- a/src/env.ts
+++ b/src/env.ts
@@ -66,3 +66,5 @@ export const env = envSchema.parse(process.env);
 
 export const getSafeEnvs = () =>
   omit(env, ['ADMIN_PASSWORD', 'JWT_SECRET', 'BITCOIN_JSON_RPC_PASSWORD', 'PAYMASTER_PRIVATE_KEY']);
+
+export const isGenerateTokenPrivate = env.NODE_ENV === 'production' && env.ADMIN_USERNAME && env.ADMIN_PASSWORD;

--- a/src/routes/token/index.ts
+++ b/src/routes/token/index.ts
@@ -5,7 +5,7 @@ import generateRoute from './generate';
 import { env } from '../../env';
 
 const tokenRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypeProvider> = (fastify, _, done) => {
-  if (env.NODE_ENV === 'production') {
+  if (env.NODE_ENV === 'production' && env.ADMIN_USERNAME && env.ADMIN_PASSWORD) {
     fastify.addHook('onRequest', async (request, reply) => {
       const { authorization } = request.headers;
       if (!authorization) {


### PR DESCRIPTION
We received feedback and found that the current token route control is confusing.

## Before
- `NODE_ENV=development`
  - Show token routes in Swagger
  - No authorization is required to generate the token
- `NODE_ENV=production` and `ADMIN_USERNAME/ADMIN_PASSWORD` is empty 
  - Hide token routes in Swagger
  - Disabled token routes
- `NODE_ENV=production` and `ADMIN_USERNAME/ADMIN_PASSWORD` is not empty
  - Hide token routes in Swagger
  - Authorization is required to generate the token

## After
- `NODE_ENV=development`
  - Show token routes in Swagger
  - No authorization is required to generate the token
- `NODE_ENV=production` and `ADMIN_USERNAME/ADMIN_PASSWORD` is empty 
  - Show token routes in Swagger
  - No authorization is required to generate the token
- `NODE_ENV=production` and `ADMIN_USERNAME/ADMIN_PASSWORD` is not empty
  - Hide token routes in Swagger
  - Authorization is required to generate the token

After applying these changes, token routes will not be disabled, ADMIN_USERNAME/ADMIN_PASSWORD is only related to whether the generated token requires authorization.

When generating a token requires authorization, it is considered that the `/token/generate` does not want to be exposed, so it will be hidden from Swagger.