### PR TITLE
chore: update sentry cron monitors config

### DIFF
--- a/src/plugins/cron.ts
+++ b/src/plugins/cron.ts
@@ -43,6 +43,10 @@ export default fp(async (fastify) => {
                   type: 'crontab',
                   value: env.UNLOCKER_CRON_SCHEDULE,
                 },
+                // create a new issue when 3 times missed or error check-ins are processed
+                failure_issue_threshold: 3,
+                // close the issue when 3 times ok check-ins are processed
+                recovery_threshold: 3,
               },
             );
             try {


### PR DESCRIPTION
When cron monitors get a missed or error report, a new sentry issue will be created. 
The occasional missing or error is within the allowed range. The `upsertMonitorConfig` passed in through `captureCheckIn` will always overwrite the settings manually modified in sentry, so we need to relax the alarm conditions through configuration.