### PR TITLE
feat: update spv proof api cache control

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,6 +8,7 @@ export enum NetworkType {
 export const CUSTOM_HEADERS = {
   ApiCache: 'x-api-cache',
   ResponseCacheable: 'x-response-cacheable',
+  ResponseCacheMaxAge: 'x-response-cache-max-age',
 };
 
 export enum ApiCacheStatus {

--- a/src/routes/rgbpp/spv.ts
+++ b/src/routes/rgbpp/spv.ts
@@ -29,6 +29,8 @@ const spvRoute: FastifyPluginCallback<Record<never, never>, Server, ZodTypeProvi
         const proof = await fastify.bitcoinSPV.getTxProof(btc_txid, confirmations);
         if (proof) {
           reply.header(CUSTOM_HEADERS.ResponseCacheable, 'true');
+          // spv proof cache for 30 minutes
+          reply.header(CUSTOM_HEADERS.ResponseCacheMaxAge, 60 * 30);
         }
         return proof;
       } catch (err) {


### PR DESCRIPTION
- Add `CUSTOM_HEADERS.ResponseCacheMaxAge` for cache control of API
- Set `/rgbpp/v1/spv/proof` cache max age to 30 minutes