### PR TITLE
fix: catch electrs not found to avoid capture to sentry

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -20,7 +20,7 @@ import cors from './plugins/cors';
 import { NetworkType } from './constants';
 import rgbppRoutes from './routes/rgbpp';
 import cronRoutes from './routes/cron';
-import { ElectrsAPIError } from './services/electrs';
+import { ElectrsAPIError, ElectrsAPINotFoundError } from './services/electrs';
 import { BitcoinRPCError } from './services/bitcoind';
 import { AppErrorCode } from './error';
 import { provider } from 'std-env';
@@ -69,7 +69,11 @@ async function routes(fastify: FastifyInstance) {
   });
 
   fastify.setErrorHandler((error, _, reply) => {
-    if (error instanceof ElectrsAPIError || error instanceof BitcoinRPCError) {
+    if (
+      error instanceof ElectrsAPIError ||
+      error instanceof ElectrsAPINotFoundError ||
+      error instanceof BitcoinRPCError
+    ) {
       reply
         .status(error.statusCode ?? HttpStatusCode.InternalServerError)
         .send({ code: error.errorCode, message: error.message });

--- a/src/services/electrs.ts
+++ b/src/services/electrs.ts
@@ -46,6 +46,8 @@ export class ElectrsAPIError extends Error {
 }
 
 export class ElectrsAPINotFoundError extends Error {
+  public errorCode = 404;
+
   constructor(message: string) {
     super(message);
     this.name = this.constructor.name;


### PR DESCRIPTION
ElectrsAPINotFoundError is a known and handled error and does not need to be capture to sentry