### PR TITLE
fix: add statusCode to ElectrsAPINotFoundError

### DIFF
--- a/src/services/electrs.ts
+++ b/src/services/electrs.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
+import axios, { AxiosError, AxiosInstance, AxiosResponse, HttpStatusCode } from 'axios';
 import { Block, Transaction, UTXO } from '../routes/bitcoin/types';
 import * as Sentry from '@sentry/node';
 import { Cradle } from '../container';
@@ -46,7 +46,8 @@ export class ElectrsAPIError extends Error {
 }
 
 export class ElectrsAPINotFoundError extends Error {
-  public errorCode = 404;
+  public errorCode = HttpStatusCode.NotFound;
+  public statusCode = HttpStatusCode.NotFound;
 
   constructor(message: string) {
     super(message);


### PR DESCRIPTION
Adding ElectrsAPINotFoundError will cause the statusCode returned by the modified `/bitcoin/v1/transaction/:btc_txid` to be inconsistent with the previous one. `statusCode` needs to be added to maintain consistency.

Found at: https://github.com/ckb-cell/rgbpp-sdk/actions/runs/8610677308/job/23596737076