### PR TITLE
feat: job retry and ElectrsAPINotFoundError delayed optimization

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -135,6 +135,11 @@ const envSchema = z.object({
    * the /rgbpp/v1/transaction/ckb-tx endpoint is called, the transaction will be added to the queue
    */
   TRANSACTION_QUEUE_JOB_DELAY: z.coerce.number().default(120 * 1000),
+  /**
+   * RGB++ CKB transaction Queue cron job attempts
+   * used to retry the transaction queue job when failed
+   */
+  TRANSACTION_QUEUE_JOB_ATTEMPTS: z.coerce.number().default(6),
 });
 
 export type Env = z.infer<typeof envSchema>;


### PR DESCRIPTION
- Added `TRANSACTION_QUEUE_JOB_ATTEMPTS` to adjust the number of job attempts
- Calculate the tolerance time for ElectrsAPINotFoundError error based on the number of job attempts and time

Taking the retry interval of 120s and the number of 6 attempts as an example: 
- In the first 120s * 2 ** 6 (about 2 hours), an ElectrsAPINotFoundError occurs, the job will be delayed 120s.
- If the ElectrsAPINotFoundError error is still thrown after 2 hours, it is considered an exception, and the job will be set to failed and enter the retry phase of the failed job. 
- For jobs that still fail after 6 retries (about 2 hours), we will no longer retry and mark as failed.

## References
- https://bitcoin.stackexchange.com/questions/78618/why-some-transactions-disappear-from-the-mempool
- https://github.com/mempool/electrs/blob/mempool/src/new_index/mempool.rs#L368
  electrs can query unconfirmed transactions, but this depends on whether the transaction is present in the Bitcoin node's mempool. electrs automatically updates its index to ensure its data is consistent with the mempool.

