### PR TITLE
fix(cron): optimize missing transactions retry logic

### DIFF
--- a/src/routes/internal/job.ts
+++ b/src/routes/internal/job.ts
@@ -23,8 +23,9 @@ const jobRoutes: FastifyPluginCallback<Record<never, never>, Server, ZodTypeProv
         },
       },
     },
-    async () => {
-      const results = await fastify.transactionManager.retryAllFailedJobs();
+    async (request) => {
+      const { max_attempts } = request.body;
+      const results = await fastify.transactionManager.retryAllFailedJobs(max_attempts);
       return results;
     },
   );


### PR DESCRIPTION
## Changes
- Adjust the target block height for retrying missing transactions job (currently the latest height, adjusted to the latest height - 1) to avoid another failure caused by the Electrs service not yet synchronizing the latest block data.
  - https://sentry-pro.mail3.land/organizations/sentry/issues/4741/?project=10&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=1h&stream_index=3
- Add max_attempts parameter support to internal API `/internal/job/retry-all-failed` to control the maximum number of retries for a failed job.

## Reviews
@Flouse @ShookLyngs @Dawn-githup 