### PR TITLE
feat: support running the app in API/background mode only

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -70,6 +70,14 @@ const envSchema = z
       .pipe(z.string().array()),
 
     /**
+     * Application Mode
+     * - full: Full application mode, includes API and background tasks.
+     * - api_only: API only mode, excludes background tasks.
+     * - background_only: Background tasks only mode, excludes API.
+     */
+    APP_MODE: z.enum(['full', 'api', 'background']).default('full'),
+
+    /**
      * Bitcoin SPV service URL
      * https://github.com/ckb-cell/ckb-bitcoin-spv-service
      */

--- a/src/env.ts
+++ b/src/env.ts
@@ -122,6 +122,14 @@ const envSchema = z
     PAYMASTER_BTC_CONTAINER_FEE_SATS: z.coerce.number().default(7000),
 
     /**
+     * Enable BTCTimeLock cell unlock cron task
+     * set to false to disable the BTCTimeLock cell unlock cron task
+     */
+    UNLOCKER_CRON_TASK_ENABLE: z
+      .enum(['true', 'false'])
+      .default('true')
+      .transform((value) => value === 'true'),
+    /**
      * BTCTimeLock cell unlock batch size
      */
     UNLOCKER_CRON_SCHEDULE: z.string().default('*/5 * * * *'),

--- a/src/options.ts
+++ b/src/options.ts
@@ -16,7 +16,7 @@ const envToLogger = {
           },
         }
       : {}),
-    level: env.LOGGER_LEVEL ?? 'debug',
+    level: 'debug',
   },
   production: {
     level: env.LOGGER_LEVEL ?? 'info',

--- a/src/plugins/cron.ts
+++ b/src/plugins/cron.ts
@@ -1,11 +1,12 @@
 import fp from 'fastify-plugin';
 import TransactionProcessor from '../services/transaction';
-import cron from 'fastify-cron';
+import cron, { Params as CronJobParams } from 'fastify-cron';
 import { Env } from '../env';
 import Unlocker from '../services/unlocker';
 
 export default fp(async (fastify) => {
   try {
+    const cronJobs: CronJobParams[] = [];
     const env: Env = fastify.container.resolve('env');
 
     const getSentryCheckIn = (monitorSlug: string, crontab: string) => {
@@ -77,31 +78,35 @@ export default fp(async (fastify) => {
         });
       },
     };
+    cronJobs.push(retryMissingTransactionsJob);
 
     // processing unlock BTC_TIME_LOCK cells
-    const unlocker: Unlocker = fastify.container.resolve('unlocker');
-    const monitorSlug = env.UNLOCKER_MONITOR_SLUG;
-    const unlockBTCTimeLockCellsJob = {
-      name: monitorSlug,
-      cronTime: env.UNLOCKER_CRON_SCHEDULE,
-      onTick: async () => {
-        fastify.Sentry.startSpan({ op: 'cron', name: monitorSlug }, async () => {
-          const { name, cronTime } = unlockBTCTimeLockCellsJob;
-          const checkIn = getSentryCheckIn(name, cronTime);
-          try {
-            await unlocker.unlockCells();
-            checkIn.ok();
-          } catch (err) {
-            checkIn.error();
-            fastify.log.error(err);
-            fastify.Sentry.captureException(err);
-          }
-        });
-      },
-    };
+    if (env.UNLOCKER_CRON_TASK_ENABLE) {
+      const unlocker: Unlocker = fastify.container.resolve('unlocker');
+      const monitorSlug = env.UNLOCKER_MONITOR_SLUG;
+      const unlockBTCTimeLockCellsJob = {
+        name: monitorSlug,
+        cronTime: env.UNLOCKER_CRON_SCHEDULE,
+        onTick: async () => {
+          fastify.Sentry.startSpan({ op: 'cron', name: monitorSlug }, async () => {
+            const { name, cronTime } = unlockBTCTimeLockCellsJob;
+            const checkIn = getSentryCheckIn(name, cronTime);
+            try {
+              await unlocker.unlockCells();
+              checkIn.ok();
+            } catch (err) {
+              checkIn.error();
+              fastify.log.error(err);
+              fastify.Sentry.captureException(err);
+            }
+          });
+        },
+      };
+      cronJobs.push(unlockBTCTimeLockCellsJob);
+    }
 
     fastify.register(cron, {
-      jobs: [retryMissingTransactionsJob, unlockBTCTimeLockCellsJob],
+      jobs: cronJobs,
     });
   } catch (err) {
     fastify.log.error(err);


### PR DESCRIPTION
## Changes
- add `APP_MODE` env var to change app mode
```
  /**
   * Application Mode
   * - full: Full application mode, includes API and background tasks.
   * - api_only: API only mode, excludes background tasks.
   * - background_only: Background tasks only mode, excludes API.
   */
  APP_MODE: z.enum(['full', 'api', 'background']).default('full'),
```
- add `UNLOCKER_CRON_TASK_ENABLE` env var to enable/disable unlock cron task
```
  /**
   * Enable BTCTimeLock cell unlock cron task
   * set to false to disable the BTCTimeLock cell unlock cron task
   */
  UNLOCKER_CRON_TASK_ENABLE: z
    .enum(['true', 'false'])
    .default('true')
    .transform((value) => value === 'true'),
```