### PR TITLE
feat(bitcoin): calculate fees when mempool.space recommend fees api unavailable

### DIFF
--- a/src/services/bitcoin/electrs.ts
+++ b/src/services/bitcoin/electrs.ts
@@ -16,7 +16,7 @@ export class ElectrsClient implements IBitcoinDataProvider {
   }
 
   public async getFeesRecommended(): Promise<RecommendedFees> {
-    throw new Error('ElectrsClient does not support getFeesRecommended');
+    throw new Error('Electrs: Recommended fees not available');
   }
 
   public async postTx({ txhex }: { txhex: string }) {

--- a/src/services/bitcoin/mempool.ts
+++ b/src/services/bitcoin/mempool.ts
@@ -2,9 +2,12 @@ import { Cradle } from '../../container';
 import { IBitcoinDataProvider } from './interface';
 import mempoolJS from '@cell-studio/mempool.js';
 import { Block, RecommendedFees, Transaction, UTXO } from './schema';
+import * as Sentry from '@sentry/node';
+import { FeesMempoolBlocks } from '@cell-studio/mempool.js/lib/interfaces/bitcoin/fees';
 
 export class MempoolClient implements IBitcoinDataProvider {
   private mempool: ReturnType<typeof mempoolJS>;
+  private defaultFee = 1;
 
   constructor(cradle: Cradle) {
     if (!cradle.env.BITCOIN_MEMPOOL_SPACE_API_URL) {
@@ -17,9 +20,81 @@ export class MempoolClient implements IBitcoinDataProvider {
     });
   }
 
+  // https://github.com/mempool/mempool/blob/dbd4d152ce831859375753fb4ca32ac0e5b1aff8/backend/src/api/fee-api.ts#L77
+  private roundUpToNearest(value: number, nearest: number): number {
+    return Math.ceil(value / nearest) * nearest;
+  }
+
+  // https://github.com/mempool/mempool/blob/dbd4d152ce831859375753fb4ca32ac0e5b1aff8/backend/src/api/fee-api.ts#L65
+  private optimizeMedianFee(
+    pBlock: FeesMempoolBlocks,
+    nextBlock: FeesMempoolBlocks | undefined,
+    previousFee?: number,
+  ): number {
+    const useFee = previousFee ? (pBlock.medianFee + previousFee) / 2 : pBlock.medianFee;
+    if (pBlock.blockVSize <= 500000) {
+      return this.defaultFee;
+    }
+    if (pBlock.blockVSize <= 950000 && !nextBlock) {
+      const multiplier = (pBlock.blockVSize - 500000) / 500000;
+      return Math.max(Math.round(useFee * multiplier), this.defaultFee);
+    }
+    return this.roundUpToNearest(useFee, this.defaultFee);
+  }
+
+  // https://github.com/mempool/mempool/blob/dbd4d152ce831859375753fb4ca32ac0e5b1aff8/backend/src/api/fee-api.ts#L22
+  private async calculateRecommendedFee(): Promise<RecommendedFees> {
+    const pBlocks = await this.mempool.bitcoin.fees.getFeesMempoolBlocks();
+    const minimumFee = this.defaultFee;
+    const defaultMinFee = this.defaultFee;
+
+    if (!pBlocks.length) {
+      return {
+        fastestFee: defaultMinFee,
+        halfHourFee: defaultMinFee,
+        hourFee: defaultMinFee,
+        economyFee: minimumFee,
+        minimumFee: minimumFee,
+      };
+    }
+
+    const firstMedianFee = this.optimizeMedianFee(pBlocks[0], pBlocks[1]);
+    const secondMedianFee = pBlocks[1]
+      ? this.optimizeMedianFee(pBlocks[1], pBlocks[2], firstMedianFee)
+      : this.defaultFee;
+    const thirdMedianFee = pBlocks[2]
+      ? this.optimizeMedianFee(pBlocks[2], pBlocks[3], secondMedianFee)
+      : this.defaultFee;
+
+    let fastestFee = Math.max(minimumFee, firstMedianFee);
+    let halfHourFee = Math.max(minimumFee, secondMedianFee);
+    let hourFee = Math.max(minimumFee, thirdMedianFee);
+    const economyFee = Math.max(minimumFee, Math.min(2 * minimumFee, thirdMedianFee));
+
+    fastestFee = Math.max(fastestFee, halfHourFee, hourFee, economyFee);
+    halfHourFee = Math.max(halfHourFee, hourFee, economyFee);
+    hourFee = Math.max(hourFee, economyFee);
+
+    return {
+      fastestFee: fastestFee,
+      halfHourFee: halfHourFee,
+      hourFee: hourFee,
+      economyFee: economyFee,
+      minimumFee: minimumFee,
+    };
+  }
+
   public async getFeesRecommended() {
-    const response = await this.mempool.bitcoin.fees.getFeesRecommended();
-    return RecommendedFees.parse(response);
+    try {
+      const response = await this.mempool.bitcoin.fees.getFeesRecommended();
+      return RecommendedFees.parse(response);
+    } catch (e) {
+      Sentry.withScope((scope) => {
+        scope.captureException(e);
+      });
+      const fees = await this.calculateRecommendedFee();
+      return RecommendedFees.parse(fees);
+    }
   }
 
   public async postTx({ txhex }: { txhex: string }) {


### PR DESCRIPTION
## Changes
Even if we request the mempool.space API through the assets api backend to get the recommended fees, it is still easy to get a 503 response on testnet.
So, add the calculation process on the service based on the logic of calculating fees on the mempool backend. When mempool.space gets recommended fees unavailable, calculate them ourselves.


![CleanShot 2024-04-29 at 18 56 56@2x](https://github.com/ckb-cell/btc-assets-api/assets/9718515/e7139d6d-1e6b-4269-963f-a04438aa13f1)

## References
- mempool backend feesApi: https://github.com/mempool/mempool/blob/master/backend/src/api/fee-api.ts


