### PR TITLE
fix: fix the state issue of inactive paymaster cell job

### DIFF
--- a/src/services/paymaster.ts
+++ b/src/services/paymaster.ts
@@ -248,7 +248,16 @@ export default class Paymaster implements IPaymaster {
       const job = await this.queue.getJob(jobId);
       if (job) {
         this.cradle.logger.info(`[Paymaster] Paymaster cell already in the queue: ${jobId}`);
-        continue;
+        // cause the issue that the job is not moved to delayed when appendCellAndSignTx throw error
+        // try to remove the inactive job and add the cell back to the queue
+        // (inactive job means the job is processed on 1 minute ago but not completed)
+        const active = await job.isActive();
+        if (active && job.processedOn && job.processedOn < Date.now() - 60_000) {
+          this.cradle.logger.warn(`[Paymaster] Remove the inactive paymaster cell: ${jobId}`);
+          await job.remove();
+        } else {
+          continue;
+        }
       }
       // add the cell to the queue
       await this.queue.add(PAYMASTER_CELL_QUEUE_NAME, cell, { jobId });
@@ -309,6 +318,7 @@ export default class Paymaster implements IPaymaster {
     try {
       const job = await this.getPaymasterCellJobByRawTx(signedTx);
       if (job) {
+        this.cradle.logger.info(`[Paymaster] Mark paymaster cell as spent: ${token}`);
         await job.moveToCompleted(null, token, false);
       }
     } catch (err) {
@@ -327,6 +337,7 @@ export default class Paymaster implements IPaymaster {
     try {
       const job = await this.getPaymasterCellJobByRawTx(signedTx);
       if (job) {
+        this.cradle.logger.info(`[Paymaster] Mark paymaster cell as unspent: ${token}`);
         await job.moveToDelayed(Date.now(), token);
       }
     } catch (err) {

--- a/src/services/transaction.ts
+++ b/src/services/transaction.ts
@@ -435,13 +435,13 @@ export default class TransactionProcessor implements ITransactionProcessor {
       const ckbRawTx = this.getCkbRawTxWithRealBtcTxid(ckbVirtualResult, txid);
       let signedTx = await this.appendTxWitnesses(txid, ckbRawTx);
 
-      // append paymaster cell and sign the transaction if needed
-      if (ckbVirtualResult.needPaymasterCell) {
-        signedTx = await this.appendPaymasterCellAndSignTx(btcTx, ckbVirtualResult, signedTx);
-      }
-      this.cradle.logger.debug(`[TransactionProcessor] Transaction signed: ${JSON.stringify(signedTx)}`);
-
       try {
+        // append paymaster cell and sign the transaction if needed
+        if (ckbVirtualResult.needPaymasterCell) {
+          signedTx = await this.appendPaymasterCellAndSignTx(btcTx, ckbVirtualResult, signedTx);
+        }
+        this.cradle.logger.debug(`[TransactionProcessor] Transaction signed: ${JSON.stringify(signedTx)}`);
+
         const txHash = await this.cradle.ckb.sendTransaction(signedTx);
         job.returnvalue = txHash;
         this.cradle.logger.info(`[TransactionProcessor] Transaction sent: ${txHash}`);


### PR DESCRIPTION
## Changes
Fixed an issue where the occupied paymaster cell was not released due to incorrect catch errors when `appendPaymasterCellAndSignTx` was processed. 

For paymaster cell jobs that were processed for more than 1 minute and whose state is still active, we filled the paymaster cell queue and considered it to be inactive. Remove and re-add inactive cells to fix the job state caused by this issue. 

(The removed and re-added paymaster cell may be in use, but we judge whether it is a live cell when get a new paymaster cell, so it will not cause new problems)