### PR TITLE
feat: support passing ckb virtual tx result JSON string as paramter

### DIFF
--- a/src/routes/rgbpp/transaction.ts
+++ b/src/routes/rgbpp/transaction.ts
@@ -30,7 +30,7 @@ const transactionRoute: FastifyPluginCallback<Record<never, never>, Server, ZodT
             }
             const parsed = CKBVirtualResult.safeParse(value);
             if (!parsed.success) {
-              throw new Error('Invalid CKB virtual result');
+              throw new Error(`Invalid CKB virtual result: ${JSON.stringify(parsed.error.flatten())}`);
             }
             return parsed.data;
           }),

--- a/test/routes/rgbpp/transaction.test.ts
+++ b/test/routes/rgbpp/transaction.test.ts
@@ -152,7 +152,7 @@ describe('/rgbpp/v1/transaction', () => {
 
     expect(response.statusCode).toBe(400);
     expect(data).toEqual({
-      message: 'Invalid CKB virtual result',
+      message: 'Invalid CKB virtual result: {"formErrors":[],"fieldErrors":{"commitment":["Required"]}}',
     });
 
     await fastify.close();


### PR DESCRIPTION
To simplify calling `/rgbpp/v1/transaction/ckb-tx` in different language SDKs, support passing `ckb_virtual_result` parameter after `JSON.stringify`

## References
- https://github.com/ckb-cell/rgbpp-sdk-python/pull/1#issue-2334990361