### PR TITLE
fix: capture unhandled electrs backuper error

### DIFF
--- a/src/services/bitcoin/index.ts
+++ b/src/services/bitcoin/index.ts
@@ -171,7 +171,15 @@ export default class BitcoinClient implements IBitcoinClient {
 
   public async postTx({ txhex }: { txhex: string }) {
     const txid = await this.call('postTx', [{ txhex }]);
-    Promise.all(this.backupers.map((backuper) => backuper.postTx({ txhex })));
+    Promise.all(
+      this.backupers.map(async (backuper) => {
+        try {
+          await backuper.postTx({ txhex });
+        } catch (err) {
+          Sentry.captureException(err);
+        }
+      }),
+    );
     return txid;
   }
 


### PR DESCRIPTION
We found some unhandled errors when posting the transaction to the backup electrs server. This PR aims to handle those errors and capture them sent to Sentry.