### PR TITLE
feat(bitcoin): add configurable default data provider per method when use mempool

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-assets-api",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "title": "Bitcoin/RGB++ Assets API",
   "description": "",
   "main": "index.js",

--- a/src/env.ts
+++ b/src/env.ts
@@ -226,6 +226,15 @@ const envSchema = z
          */
         BITCOIN_ELECTRS_API_URL: z.string().optional(),
         /**
+         * The IBitcoinClient methods to use Electrs as default data provider
+         * use electrs as default, mempool.space as fallback
+         */
+        BITCOIN_METHODS_USE_ELECTRS_BY_DEFAULT: z
+          .string()
+          .default('')
+          .transform((value) => value.split(','))
+          .pipe(z.string().array()),
+        /**
          * Bitcoin data provider, support mempool and electrs
          * use mempool.space as default, electrs as fallback
          * change to electrs if you want to use electrs as default and mempool.space as fallback

--- a/src/services/bitcoin/index.ts
+++ b/src/services/bitcoin/index.ts
@@ -102,20 +102,32 @@ export default class BitcoinClient implements IBitcoinClient {
     method: K,
     ...args: MethodParameters<IBitcoinDataProvider, K>
   ): Promise<MethodReturnType<IBitcoinDataProvider, K>> {
+    const dataSource = { source: this.source, fallback: this.fallback };
+
+    const { env } = this.cradle;
+    if (env.BITCOIN_DATA_PROVIDER === 'mempool' && env.BITCOIN_METHODS_USE_ELECTRS_BY_DEFAULT.includes(method)) {
+      if (this.fallback) {
+        dataSource.source = this.fallback;
+        dataSource.fallback = this.source;
+      } else {
+        this.cradle.logger.warn('No fallback provider, skip using Electrs as default');
+      }
+    }
+
     try {
       this.cradle.logger.debug(`Calling ${method} with args: ${JSON.stringify(args)}`);
-      const result = await (this.source[method] as Function).apply(this.source, args);
+      const result = await (dataSource.source[method] as Function).apply(this.source, args);
       return result as MethodReturnType<IBitcoinDataProvider, K>;
     } catch (err) {
       let calledError = err;
       this.cradle.logger.error(err);
       Sentry.captureException(err);
-      if (this.fallback) {
+      if (dataSource.fallback) {
         this.cradle.logger.warn(
-          `Fallback to ${this.fallback.constructor.name} due to error: ${(err as Error).message}`,
+          `Fallback to ${dataSource.fallback.constructor.name} due to error: ${(err as Error).message}`,
         );
         try {
-          const result = await (this.fallback[method] as Function).apply(this.fallback, args);
+          const result = await (dataSource.fallback[method] as Function).apply(this.fallback, args);
           return result as MethodReturnType<IBitcoinDataProvider, K>;
         } catch (fallbackError) {
           this.cradle.logger.error(fallbackError);


### PR DESCRIPTION
## New Env
Only available when `BITCOIN_DATA_PROVIDER = mempool`
```typescript
 /**
   * The IBitcoinClient methods to use Electrs as default data provider
   * use electrs as default, mempool.space as fallback
   */
  BITCOIN_METHODS_USE_ELECTRS_BY_DEFAULT: z
    .string()
    .default('')
    .transform((value) => value.split(','))
    .pipe(z.string().array()),
```

This will make some [`IBitcoinDataProvider`](https://github.com/utxostack/btc-assets-api/blob/develop/src/services/bitcoin/interface.ts#L3) methods use `Electrs` as the primary data provider in order to resolve the issue: https://github.com/utxostack/btc-assets-api/issues/221. 

The configured methods will prioritize using the `electrs` as the primary data provider and fallback to `mempool.space` API when electrs is not available.