### PR TITLE
chore(Dockerfile): bump the base image to node:22-slim (lts-slim⁠)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
Try to fix an error in [the `docker-build-push` CI](https://github.com/utxostack/btc-assets-api/actions/runs/13324329035/job/37214404228):
 > [linux/amd64 stage-0 5/6] RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile:
0.232 Error: Cannot find matching keyid: {"signatures":[{"sig":"MEUCICK4bLF6Ywa/faC/4PIt094EbceYRe19bBHQW0rAS/dGAiEA8/ofAy07ETUbu+ca1PM4HDYqcHOjBlvgvdWvG0hy3as=","keyid":"SHA256:DhQ8wR5APBvFHLF/+Tc+AYvPOdTpcIDqOhxsBHRwC7U"}],"keys":[{"expires":null,"keyid":"SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA","keytype":"ecdsa-sha2-nistp256","scheme":"ecdsa-sha2-nistp256","key":"MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Olb3zMAFFxXKHiIkQO5cJ3Yhl5i6UPp+IhuteBJbuHcA5UogKo0EWtlWwW6KSaKoTNEYL7JlCQiVnkhBktUgg=="}]}
0.232     at verifySignature (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21535:47)
0.232     at fetchLatestStableVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21553:5)
0.232     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
0.232     at async fetchLatestStableVersion2 (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:21672:14)
0.232     at async Engine.getDefaultVersion (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22298:23)
0.232     at async Engine.executePackageManagerRequest (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:22396:47)
0.232     at async Object.runMain (/usr/local/lib/node_modules/corepack/dist/lib/corepack.cjs:23102:5)
0.232
0.232 Node.js v20.18.3

## dispatched workflow to test
- https://github.com/utxostack/btc-assets-api/actions/runs/13327568623/job/37224097504