### PR TITLE
chore(CD): disable the signet deploy job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,18 +26,19 @@ jobs:
             cd ${{ secrets.SSH_WORK_DIR }}
             echo ${{ secrets.PACKAGE_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             bash ./update.sh
-  deploy-signet:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Deploy Signet
-        uses: appleboy/ssh-action@v1.0.3
-        with:
-          host: ${{ secrets.SSH_HOST_SIGNET }}
-          username: ${{ secrets.SSH_USERNAME_SIGNET }}
-          password: ${{ secrets.PASSWORD }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          script: |
-            cd ${{ secrets.SSH_WORK_DIR_SIGNET }}
-            echo ${{ secrets.PACKAGE_TOKEN }} | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
-            bash ./update.sh
+  
+  # The signet instance is maintained by the https://github.com/ckb-devrel team.
+  # deploy-signet:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Deploy Signet
+  #       uses: appleboy/ssh-action@v1.0.3
+  #       with:
+  #         host: ${{ secrets.SSH_HOST_SIGNET }}
+  #         username: ${{ secrets.SSH_USERNAME_SIGNET }}
+  #         password: ${{ secrets.PASSWORD }}
+  #         key: ${{ secrets.SSH_PRIVATE_KEY }}
+  #         script: |
+  #           cd ${{ secrets.SSH_WORK_DIR_SIGNET }}
+  #           echo ${{ secrets.PACKAGE_TOKEN }} | sudo docker login ghcr.io -u ${{ github.actor }} --password-stdin
+  #           bash ./update.sh


### PR DESCRIPTION
The signet instance is maintained by the https://github.com/ckb-devrel team.