### PR TITLE
fix(healthcheck): Add network path to mempool health check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tmp
 .env
 
 node_modules
+node-compile-cache/
 
 .idea
 *.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "btc-assets-api",
-  "version": "2.5.11",
+  "version": "2.5.12",
   "title": "Bitcoin/RGB++ Assets API",
   "description": "",
   "main": "index.js",

--- a/src/plugins/healthcheck.ts
+++ b/src/plugins/healthcheck.ts
@@ -19,7 +19,10 @@ export default fp(async (fastify) => {
   });
 
   fastify.addHealthCheck('mempool', async () => {
-    await axios.get(`${env.BITCOIN_MEMPOOL_SPACE_API_URL}/api/blocks/tip/height`);
+    // NETWORK: z.enum(['mainnet', 'testnet', 'signet']).default('testnet')
+    const networkPath = env.NETWORK === 'mainnet' ? '' : `/${env.NETWORK}`;
+
+    await axios.get(`${env.BITCOIN_MEMPOOL_SPACE_API_URL}${networkPath}/api/blocks/tip/height`);
   });
 
   fastify.addHealthCheck('electrs', async () => {


### PR DESCRIPTION
To support different Bitcoin networks, a practical example of the final URL might look like:
- Mainnet: https://mempool.space/api/blocks/tip/height
- Testnet: https://mempool.space/testnet/api/blocks/tip/height
